### PR TITLE
hotfix: group dependencies depends on target

### DIFF
--- a/cqp-api/build.gradle.kts
+++ b/cqp-api/build.gradle.kts
@@ -20,17 +20,19 @@ dependencies {
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 
-    testImplementation("org.mockito:mockito-core:4.11.0")
-    testImplementation("org.mockito:mockito-inline:4.11.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
-    testImplementation(libs.jackson)
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
+
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
     testImplementation("org.assertj:assertj-core:3.21.0")
     testImplementation("org.awaitility:awaitility:4.1.0")
     testImplementation(libs.bundles.testcontainers)
+
+    testImplementation(libs.jackson)
     testImplementation(libs.lombok)
     testAnnotationProcessor(libs.lombok)
 }

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -8,21 +8,23 @@ description = "Chem query platform. Compound quick search"
 version = "0.0.13"
 
 dependencies {
-    implementation("com.lightbend.akka.discovery:akka-discovery-aws-api_2.13:1.5.0-M1")
-    implementation("com.typesafe.akka:akka-discovery_2.13:2.9.0-M2")
-    implementation("com.lightbend.akka.management:akka-management_2.13:1.5.0-M1")
-    implementation("com.lightbend.akka.management:akka-management-cluster-bootstrap_2.13:1.5.0-M1")
-
-    implementation("com.lightbend.akka:akka-stream-alpakka-slick_2.13:6.0.2")
-    implementation("com.typesafe.akka:akka-stream_2.13:2.9.0-M2")
     implementation("com.typesafe:config:1.4.2")
 
-    implementation("com.typesafe.akka:akka-actor-typed_2.13:2.9.0-M2")
-    implementation("com.typesafe.akka:akka-slf4j_2.13:2.9.0-M2")
     implementation("com.typesafe.akka:akka-bom_2.13:2.9.0-M2")
+
+    implementation("com.typesafe.akka:akka-actor-typed_2.13:2.9.0-M2")
+    implementation("com.typesafe.akka:akka-stream_2.13:2.9.0-M2")
     implementation("com.typesafe.akka:akka-stream-typed_2.13:2.9.0-M2")
+
+    implementation("com.typesafe.akka:akka-slf4j_2.13:2.9.0-M2")
+    implementation("com.typesafe.akka:akka-discovery_2.13:2.9.0-M2")
     implementation("com.typesafe.akka:akka-serialization-jackson_2.13:2.9.0-M2")
     implementation("com.typesafe.akka:akka-cluster-typed_2.13:2.9.0-M2")
+
+    implementation("com.lightbend.akka:akka-stream-alpakka-slick_2.13:6.0.2")
+    implementation("com.lightbend.akka.management:akka-management_2.13:1.5.0-M1")
+    implementation("com.lightbend.akka.management:akka-management-cluster-bootstrap_2.13:1.5.0-M1")
+    implementation("com.lightbend.akka.discovery:akka-discovery-aws-api_2.13:1.5.0-M1")
 
     implementation(libs.common.text)
     implementation(libs.javax.validation)
@@ -31,14 +33,17 @@ dependencies {
 
     testImplementation("com.typesafe.akka:akka-actor-testkit-typed_2.13:2.9.0-M2")
     testImplementation("com.typesafe.akka:akka-testkit_2.13:2.9.0-M2")
-    testImplementation("org.mockito:mockito-core:4.11.0")
-    testImplementation("org.mockito:mockito-inline:4.11.0")
+
     testImplementation(platform("org.junit:junit-bom:5.10.3"))
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
+
+    testImplementation("org.mockito:mockito-core:4.11.0")
+    testImplementation("org.mockito:mockito-inline:4.11.0")
     testImplementation("org.assertj:assertj-core:3.21.0")
     testImplementation("org.awaitility:awaitility:4.1.0")
+
     testImplementation(libs.bundles.testcontainers)
     testImplementation(libs.lombok)
     testAnnotationProcessor(libs.lombok)


### PR DESCRIPTION
dependencies "akka" are grouped into "akka"
dependencies "lighbend" are grouped into "lightbend"


This makes easier to distinguish types of dependencies
