### PR TITLE
hotfix: replace dependencies version with BOM

### DIFF
--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -155,7 +155,7 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
                 doLast {
                     val file = zipBundle.get().archiveFile.get().asFile
                     val boundary = "----WebKitFormBoundary7MA4YWxkTrZu0gW"
-                    val url = java.net.URL("https://central.sonatype.com/api/v1/publisher/upload")
+                    val url = uri("https://central.sonatype.com/api/v1/publisher/upload").toURL()
 
                     val username = project.findProperty("mavenCentralUsername") as String?
                             ?: System.getenv("MAVEN_CENTRAL_USERNAME")

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -12,7 +12,7 @@ val akkaVersion: String = "2.9.0-M2"
 dependencies {
     implementation("com.typesafe:config:1.4.2")
 
-    implementation(platform("com.typesafe.akka:akka-bom_2.13:2.9.0-M2"))
+    implementation(platform("com.typesafe.akka:akka-bom_2.13:$akkaVersion"))
 
     implementation("com.typesafe.akka:akka-actor-typed_2.13")
     implementation("com.typesafe.akka:akka-stream_2.13")

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -7,19 +7,21 @@ plugins {
 description = "Chem query platform. Compound quick search"
 version = "0.0.13"
 
+val akkaVersion: String = "2.9.0-M2"
+
 dependencies {
     implementation("com.typesafe:config:1.4.2")
 
-    implementation("com.typesafe.akka:akka-bom_2.13:2.9.0-M2")
+    implementation(platform("com.typesafe.akka:akka-bom_2.13:2.9.0-M2"))
 
-    implementation("com.typesafe.akka:akka-actor-typed_2.13:2.9.0-M2")
-    implementation("com.typesafe.akka:akka-stream_2.13:2.9.0-M2")
-    implementation("com.typesafe.akka:akka-stream-typed_2.13:2.9.0-M2")
+    implementation("com.typesafe.akka:akka-actor-typed_2.13")
+    implementation("com.typesafe.akka:akka-stream_2.13")
+    implementation("com.typesafe.akka:akka-stream-typed_2.13")
 
-    implementation("com.typesafe.akka:akka-slf4j_2.13:2.9.0-M2")
-    implementation("com.typesafe.akka:akka-discovery_2.13:2.9.0-M2")
-    implementation("com.typesafe.akka:akka-serialization-jackson_2.13:2.9.0-M2")
-    implementation("com.typesafe.akka:akka-cluster-typed_2.13:2.9.0-M2")
+    implementation("com.typesafe.akka:akka-slf4j_2.13")
+    implementation("com.typesafe.akka:akka-discovery_2.13")
+    implementation("com.typesafe.akka:akka-serialization-jackson_2.13")
+    implementation("com.typesafe.akka:akka-cluster-typed_2.13")
 
     implementation("com.lightbend.akka:akka-stream-alpakka-slick_2.13:6.0.2")
     implementation("com.lightbend.akka.management:akka-management_2.13:1.5.0-M1")


### PR DESCRIPTION
### Description:

Since "BOM" dependencies already present in list, it is used to manage all akka dependencies

### Issue Link:

Closes # (Add a link to the related issue, e.g., Closes #123 or Fixes #456) 
