### PR TITLE
refactor: decouple "cqp-api" from "cqp-core"

### DIFF
--- a/cqp-api/build.gradle.kts
+++ b/cqp-api/build.gradle.kts
@@ -6,11 +6,10 @@ plugins {
 
 group = "com.quantori"
 description = "Chem query platform. Storage API"
-version = "0.0.15"
+version = "0.0.16"
 
 dependencies {
     implementation("commons-codec:commons-codec:1.15")
-    implementation("com.quantori:cqp-core:0.0.13")
 
     implementation(libs.javax.validation)
     implementation(libs.bundles.indigo)

--- a/cqp-api/src/main/java/com/quantori/cqp/api/Criteria.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/Criteria.java
@@ -1,0 +1,4 @@
+package com.quantori.cqp.api;
+
+/** A criteria interface that is used for filtering molecules by their properties. */
+public interface Criteria {}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/DataStorage.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/DataStorage.java
@@ -1,0 +1,19 @@
+package com.quantori.cqp.api;
+
+import com.quantori.cqp.api.model.StorageRequest;
+
+import java.util.List;
+
+public interface DataStorage<U extends StorageUploadItem, I extends StorageItem> {
+  /**
+   * Creates a molecules/reaction writer that is used to persist items to a storage.
+   *
+   * <p>For more details see {@link ItemWriter}
+   *
+   * @param libraryId an id of a library to which molecules will be persisted
+   * @return an instance of item writer
+   */
+  ItemWriter<U> itemWriter(String libraryId);
+
+  List<SearchIterator<I>> searchIterator(StorageRequest storageRequest);
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/ItemWriter.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/ItemWriter.java
@@ -1,0 +1,22 @@
+package com.quantori.cqp.api;
+
+/**
+ * An item writer to store items (molecules and reactions) to a storage.
+ *
+ * @param <T> type off entity to write
+ */
+public interface ItemWriter<T> extends AutoCloseable {
+
+  /**
+   * Write a single item to a storage.
+   *
+   * @param item an item to store
+   */
+  void write(T item);
+
+  /** Flush items from a buffer to a storage. */
+  void flush();
+
+  /** Close an item writer and persist all items. */
+  void close();
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/MoleculesMatcher.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/MoleculesMatcher.java
@@ -1,8 +1,7 @@
 package com.quantori.cqp.api;
 
-
-import com.quantori.cqp.core.model.ExactParams;
-import com.quantori.cqp.core.model.SubstructureParams;
+import com.quantori.cqp.api.model.ExactParams;
+import com.quantori.cqp.api.model.SubstructureParams;
 
 /**
  * A molecules matcher for exact and substructure search.

--- a/cqp-api/src/main/java/com/quantori/cqp/api/ReactionsMatcher.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/ReactionsMatcher.java
@@ -1,6 +1,6 @@
 package com.quantori.cqp.api;
 
-import com.quantori.cqp.core.model.SubstructureParams;
+import com.quantori.cqp.api.model.SubstructureParams;
 
 /**
  * A reactions matcher for exact and substructure search.

--- a/cqp-api/src/main/java/com/quantori/cqp/api/SearchItem.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/SearchItem.java
@@ -1,0 +1,7 @@
+package com.quantori.cqp.api;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+public interface SearchItem { // S - Search item
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/SearchIterator.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/SearchIterator.java
@@ -1,0 +1,58 @@
+package com.quantori.cqp.api;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Iterator fetches list of items(batch) on each iteration.
+ *
+ * @author simar.mugattarov
+ */
+public interface SearchIterator<R> extends Closeable {
+
+  /** Empty iterator returns just empty list. */
+  static <R> SearchIterator<R> empty(String storageName) {
+    return new SearchIterator<R>() {
+      @Override
+      public List<R> next() {
+        return List.of();
+      }
+
+      @Override
+      public String getStorageName() {
+        return storageName;
+      }
+
+      @Override
+      public List<String> getLibraryIds() {
+        return List.of();
+      }
+    };
+  }
+
+  /**
+   * Get next matched item list. If returned list is empty, then assume the search is completed. Pay
+   * attention this expected to be thread safe. Code using this element expects it to be thread safe
+   * in blocking manner.
+   *
+   * @return a list of matched items or empty list otherwise
+   */
+  @NotNull
+  List<R> next();
+
+  /**
+   * Closes an iterator.
+   *
+   * <p>The default implementation does nothing.
+   *
+   * @throws IOException In case an iterator cannot be closed, {@code IOException} must be thrown.
+   */
+  @Override
+  default void close() throws IOException {}
+
+  String getStorageName();
+
+  List<String> getLibraryIds();
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/StorageItem.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/StorageItem.java
@@ -1,0 +1,7 @@
+package com.quantori.cqp.api;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+public interface StorageItem { // I - storage Item
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/StorageMolecules.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/StorageMolecules.java
@@ -1,17 +1,13 @@
 package com.quantori.cqp.api;
 
+import com.quantori.cqp.api.model.ExactParams;
 import com.quantori.cqp.api.model.Flattened;
+import com.quantori.cqp.api.model.SearchProperty;
+import com.quantori.cqp.api.model.SimilarityParams;
+import com.quantori.cqp.api.model.SortParams;
+import com.quantori.cqp.api.model.StorageRequest;
+import com.quantori.cqp.api.model.SubstructureParams;
 import com.quantori.cqp.api.model.upload.Molecule;
-import com.quantori.cqp.core.model.Criteria;
-import com.quantori.cqp.core.model.DataStorage;
-import com.quantori.cqp.core.model.ExactParams;
-import com.quantori.cqp.core.model.ItemWriter;
-import com.quantori.cqp.core.model.SearchIterator;
-import com.quantori.cqp.core.model.SearchProperty;
-import com.quantori.cqp.core.model.SimilarityParams;
-import com.quantori.cqp.core.model.SortParams;
-import com.quantori.cqp.core.model.StorageRequest;
-import com.quantori.cqp.core.model.SubstructureParams;
 
 import java.util.List;
 
@@ -93,8 +89,8 @@ public interface StorageMolecules extends DataStorage<Molecule, Flattened.Molecu
    * @return an iterator of found molecules
    */
   SearchIterator<Flattened.Molecule> searchExact(
-          String[] libraryIds, byte[] moleculeExactFingerprint, List<SearchProperty> properties,
-          ExactParams exactParams, SortParams sortParams, Criteria criteria);
+      String[] libraryIds, byte[] moleculeExactFingerprint, List<SearchProperty> properties,
+      ExactParams exactParams, SortParams sortParams, Criteria criteria);
 
   /**
    * Perform the substructure molecules search by a fingerprint.
@@ -109,8 +105,8 @@ public interface StorageMolecules extends DataStorage<Molecule, Flattened.Molecu
    * @return an iterator of found molecules
    */
   SearchIterator<Flattened.Molecule> searchSub(
-    String[] libraryIds, byte[] queryFingerprint, List<SearchProperty> properties,
-    SubstructureParams substructureParams, SortParams sortParams, Criteria criteria);
+      String[] libraryIds, byte[] queryFingerprint, List<SearchProperty> properties,
+      SubstructureParams substructureParams, SortParams sortParams, Criteria criteria);
 
   /**
    * Perform the similarity molecules search by a fingerprint.
@@ -125,8 +121,8 @@ public interface StorageMolecules extends DataStorage<Molecule, Flattened.Molecu
    * @return an iterator of found molecules
    */
   SearchIterator<Flattened.Molecule> searchSim(
-          String[] libraryIds, byte[] moleculeSimilarityFingerprint, List<SearchProperty> properties,
-          SimilarityParams similarityParams, SortParams sortParams, Criteria criteria);
+      String[] libraryIds, byte[] moleculeSimilarityFingerprint, List<SearchProperty> properties,
+      SimilarityParams similarityParams, SortParams sortParams, Criteria criteria);
 
   /**
    * Perform the listing of all molecules in specified libraries

--- a/cqp-api/src/main/java/com/quantori/cqp/api/StorageReactions.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/StorageReactions.java
@@ -1,13 +1,11 @@
 package com.quantori.cqp.api;
 
+import com.quantori.cqp.api.model.ExactParams;
 import com.quantori.cqp.api.model.Flattened;
+import com.quantori.cqp.api.model.ReactionParticipantRole;
+import com.quantori.cqp.api.model.StorageRequest;
+import com.quantori.cqp.api.model.SubstructureParams;
 import com.quantori.cqp.api.model.upload.ReactionUploadDocument;
-import com.quantori.cqp.core.model.DataStorage;
-import com.quantori.cqp.core.model.ExactParams;
-import com.quantori.cqp.core.model.ReactionParticipantRole;
-import com.quantori.cqp.core.model.SearchIterator;
-import com.quantori.cqp.core.model.StorageRequest;
-import com.quantori.cqp.core.model.SubstructureParams;
 
 import java.util.List;
 
@@ -116,7 +114,7 @@ public interface StorageReactions extends DataStorage<ReactionUploadDocument, Fl
    * @return an iterator of found reactions
    */
   SearchIterator<Flattened.Reaction> searchExact(
-          String[] libraryIds, byte[] participantExactFingerprint, ExactParams exactParams, ReactionParticipantRole role);
+      String[] libraryIds, byte[] participantExactFingerprint, ExactParams exactParams, ReactionParticipantRole role);
 
   /**
    * Perform the substructure reactions search by a reaction participant fingerprint.

--- a/cqp-api/src/main/java/com/quantori/cqp/api/StorageUploadItem.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/StorageUploadItem.java
@@ -1,0 +1,7 @@
+package com.quantori.cqp.api;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+public interface StorageUploadItem { // U - storage Upload item
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/indigo/IndigoMatcher.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/indigo/IndigoMatcher.java
@@ -4,8 +4,8 @@ import com.epam.indigo.Indigo;
 import com.epam.indigo.IndigoObject;
 import com.quantori.cqp.api.MoleculesMatcher;
 import com.quantori.cqp.api.ReactionsMatcher;
-import com.quantori.cqp.core.model.ExactParams;
-import com.quantori.cqp.core.model.SubstructureParams;
+import com.quantori.cqp.api.model.ExactParams;
+import com.quantori.cqp.api.model.SubstructureParams;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.function.BinaryOperator;
@@ -90,10 +90,7 @@ public class  IndigoMatcher implements ReactionsMatcher {
   }
 
   @Override
-  public boolean isReactionSubstructureMatch(
-      String reaction,
-      SubstructureParams substructureParams
-  ) {
+  public boolean isReactionSubstructureMatch(String reaction, SubstructureParams substructureParams) {
     var searchQuery = substructureParams.getSearchQuery();
     var heteroatoms = substructureParams.isHeteroatoms();
     return StringUtils.isBlank(searchQuery)

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/ConjunctionCriteria.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/ConjunctionCriteria.java
@@ -1,6 +1,6 @@
 package com.quantori.cqp.api.model;
 
-import com.quantori.cqp.core.model.Criteria;
+import com.quantori.cqp.api.Criteria;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/ExactParams.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/ExactParams.java
@@ -1,0 +1,15 @@
+package com.quantori.cqp.api.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/** An object to store parameters of exact search for molecules and reactions. */
+@SuperBuilder
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class ExactParams extends SearchParams {}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/FieldCriteria.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/FieldCriteria.java
@@ -1,6 +1,6 @@
 package com.quantori.cqp.api.model;
 
-import com.quantori.cqp.core.model.Criteria;
+import com.quantori.cqp.api.Criteria;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/Flattened.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/Flattened.java
@@ -1,8 +1,8 @@
 package com.quantori.cqp.api.model;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.quantori.cqp.core.model.SearchItem;
-import com.quantori.cqp.core.model.StorageItem;
+import com.quantori.cqp.api.SearchItem;
+import com.quantori.cqp.api.StorageItem;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/ReactionParticipantRole.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/ReactionParticipantRole.java
@@ -1,0 +1,34 @@
+package com.quantori.cqp.api.model;
+
+/** Reaction participants roles. Usually used to mark what expression represents. */
+@SuppressWarnings("java:S115")
+public enum ReactionParticipantRole {
+  /** It is the substance formed from chemical reactions. */
+  product,
+  /** It is a substance that is present at the start of a chemical reaction. */
+  reactant,
+  /**
+   * It is, a spectator ion is an ion that exists as a reactant and a product in a chemical
+   * equation. Possible spectators are solvent and catalyst
+   */
+  spectator,
+  /** Substance might represent any of other types. */
+  any,
+  /**
+   * Expression doesn't represent any of reaction part. If entity has that role that means a
+   * molecule, not a reaction
+   */
+  none,
+  /** It is a substance that dissolves a solute, resulting in a solution. Example of a spectator */
+  solvent,
+  /**
+   * Catalyst is a substance that increases the rate of the process of a chemical reaction. Example
+   * of a spectator
+   */
+  catalyst,
+  /**
+   * It is a process that leads to the chemical transformation of one set of chemical substances to
+   * another.
+   */
+  reaction
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/SearchParams.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/SearchParams.java
@@ -1,0 +1,17 @@
+package com.quantori.cqp.api.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/** An object to store parameters of exact search for molecules and reactions. */
+@SuperBuilder
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public abstract class SearchParams {
+  private String searchQuery;
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/SearchProperty.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/SearchProperty.java
@@ -1,0 +1,20 @@
+package com.quantori.cqp.api.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Search properties, added to a search to limit its results.
+ *
+ * <p>Consists of a property name, a property value and a logical operator that should be applied to
+ * a property.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchProperty {
+  private String property;
+  private String logicalOperator;
+  private String value;
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/SearchType.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/SearchType.java
@@ -1,0 +1,8 @@
+package com.quantori.cqp.api.model;
+
+public enum SearchType {
+  exact,
+  substructure,
+  similarity,
+  all
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/SimilarityParams.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/SimilarityParams.java
@@ -1,0 +1,60 @@
+package com.quantori.cqp.api.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Similarity parameters of a search request.
+ *
+ * <p>Includes similarity algorithm and its input.
+ */
+@Jacksonized
+@SuperBuilder
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class SimilarityParams extends SearchParams {
+  private SimilarityMetric metric;
+  private float minSim;
+  private float maxSim;
+  private float alpha;
+  private float beta;
+
+  /** Supported enumeration of similarity algorithms. */
+  @Getter
+  @RequiredArgsConstructor
+  public enum SimilarityMetric {
+    /**
+     * The <em>tanimoto</em> similarity algorithm.
+     *
+     * @see <a href="https://en.wikipedia.org/wiki/Chemical_similarity">external:tanimoto</a>
+     */
+    tanimoto("tanimoto"),
+    /**
+     * The <em>tversky</em> similarity algorithm.
+     *
+     * @see <a
+     *     href="https://www.daylight.com/meetings/mug97/Bradshaw/MUG97/tv_tversky.html">external:tversky</a>
+     */
+    tversky("tversky"),
+    /**
+     * The <em>euclid</em> similarity algorithm.
+     *
+     * @see <a
+     *     href="https://www.baeldung.com/cs/euclidean-distance-vs-cosine-similarity">external:euclid
+     *     distance</a>
+     */
+    euclid("euclid-cub"),
+    /** Unknown type of similarity algorithm. */
+    none("");
+
+    @JsonValue private final String value;
+  }
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/SortParams.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/SortParams.java
@@ -1,0 +1,191 @@
+package com.quantori.cqp.api.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import javax.validation.constraints.NotNull;
+
+/** Sort parameters. Immutable object, all methods are safe. */
+@SuppressWarnings("unused")
+public record SortParams(List<Sort> sortList) {
+
+  private static final SortParams EMPTY = new SortParams(List.of());
+
+  /**
+   * Constructs a {@code SortParams} object with the specified list of sort rules.
+   *
+   * <p>If the list contains multiple sort rules for the same field, only the first occurrence of
+   * the sort rule for that field in the list is applied, and subsequent sort rules for the same
+   * field are ignored. It is up to client to make sure the sort rules provided
+   */
+  public SortParams(@NotNull List<Sort> sortList) {
+    Objects.requireNonNull(sortList);
+    this.sortList = List.copyOf(sortList);
+  }
+
+  /**
+   * Empty list of sorting parameters.
+   *
+   * @return empty list sort parameters
+   */
+  @NotNull
+  public static SortParams empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Create sorting parameters of a single sorting parameter.
+   *
+   * @param sort rule
+   * @return sort parameters
+   */
+  public static @NotNull SortParams of(@NotNull Sort sort) {
+    Objects.requireNonNull(sort);
+    return ofSortList(List.of(sort));
+  }
+
+  /**
+   * Create the list of sort parameters.
+   *
+   * @param sorts rules
+   * @return list of sort parameters
+   */
+  public static SortParams of(Sort... sorts) {
+    return ofSortList(List.of(sorts));
+  }
+
+  /**
+   * Create the list of sort parameters.
+   *
+   * <p>If the list contains multiple sort rules for the same field, only the first occurrence of
+   * the sort rule for that field in the list is applied, and subsequent sort rules for the same
+   * field are ignored. It is up to client to make sure the sort rules provided
+   *
+   * @param sortList of parameters
+   * @return list of sorting parameters
+   */
+  public static SortParams ofSortList(@NotNull List<Sort> sortList) {
+    Objects.requireNonNull(sortList);
+    if (sortList.isEmpty()) {
+      return EMPTY;
+    }
+    return new SortParams(sortList);
+  }
+
+  /**
+   * Create new sort parameters with new sort rule added at the end of sort list.
+   *
+   * @param sort parameter
+   * @return new sort parameters
+   */
+  public SortParams addLastSort(@NotNull Sort sort) {
+    Objects.requireNonNull(sort);
+    var list = new ArrayList<>(sortList);
+    list.add(sort);
+    return new SortParams(list);
+  }
+
+  /**
+   * Create new sort parameters with new sort rule added at the end of sort list.
+   *
+   * @param fieldName {@link Sort#fieldName}
+   * @param order {@link Sort#order}
+   * @param type {@link Sort#type}
+   * @return new sort parameters
+   */
+  public SortParams addLastSort(String fieldName, Order order, Type type) {
+    return addLastSort(new Sort(fieldName, order, type));
+  }
+
+  /**
+   * Create new sort parameters with new sort rule added at the end of sort list.
+   *
+   * @param sort parameter
+   * @return new sort parameters
+   */
+  public SortParams addFirstSort(@NotNull Sort sort) {
+    Objects.requireNonNull(sort);
+    List<Sort> list = new ArrayList<>();
+    list.add(sort);
+    list.addAll(this.sortList());
+    return SortParams.ofSortList(list);
+  }
+
+  /**
+   * Create new sort parameters with new sort rule added at the end of sort list.
+   *
+   * @param fieldName {@link Sort#fieldName}
+   * @param order {@link Sort#order}
+   * @param type {@link Sort#type}
+   * @return new sort parameters
+   */
+  public SortParams addFirstSort(String fieldName, Order order, Type type) {
+    return addFirstSort(new Sort(fieldName, order, type));
+  }
+
+  public enum Type {
+    GENERAL,
+    NESTED
+  }
+
+  public enum Order {
+    ASC {
+      @Override
+      public Order invert() {
+        return DESC;
+      }
+    },
+    DESC {
+      @Override
+      public Order invert() {
+        return ASC;
+      }
+    };
+
+    /**
+     * Create sort rule of general field.
+     *
+     * @param fieldName to sort by
+     */
+    public Sort general(String fieldName) {
+      return new Sort(fieldName, this, Type.GENERAL);
+    }
+
+    /**
+     * Create sort rule of nested field.
+     *
+     * @param fieldName to sort by
+     */
+    public Sort nested(String fieldName) {
+      return new Sort(fieldName, this, Type.NESTED);
+    }
+
+    private Sort of(String fieldName, Type type) {
+      return new Sort(fieldName, this, type);
+    }
+
+    /** Invert order <i>desc</i> to <i>asc</i> and <i>asc</i> to <i>desc</i>. */
+    public abstract Order invert();
+  }
+
+  public record Sort(String fieldName, Order order, @NotNull Type type) {
+
+    /**
+     * Invert sort order of field.
+     *
+     * @return inverted order of current sort
+     */
+    public Sort invertOrder() {
+      return new Sort(this.fieldName, order.invert(), type);
+    }
+
+    /**
+     * Create a sort parameters list with single sort rule from this sort.
+     *
+     * @return sort parameters list
+     */
+    public SortParams asSortParams() {
+      return SortParams.of(this);
+    }
+  }
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/StorageRequest.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/StorageRequest.java
@@ -1,0 +1,25 @@
+package com.quantori.cqp.api.model;
+
+import java.util.List;
+import java.util.Map;
+
+import com.quantori.cqp.api.Criteria;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StorageRequest {
+  private final String storageName;
+  private final List<String> indexIds;
+  private final SearchType searchType;
+  private final Map<String, String> searchProperties;
+  private ExactParams exactParams;
+  private SubstructureParams substructureParams;
+  private SimilarityParams similarityParams;
+  private ReactionParticipantRole role;
+  private byte[] queryFingerprint;
+  private List<SearchProperty> properties;
+  private SortParams sortParams;
+  private Criteria criteria;
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/SubstructureParams.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/SubstructureParams.java
@@ -1,0 +1,17 @@
+package com.quantori.cqp.api.model;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+/** Substructure parameters of a search request. */
+@SuperBuilder
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+public class SubstructureParams extends SearchParams {
+  private boolean heteroatoms;
+}

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/upload/Molecule.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/upload/Molecule.java
@@ -1,7 +1,7 @@
 package com.quantori.cqp.api.model.upload;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.quantori.cqp.core.model.StorageUploadItem;
+import com.quantori.cqp.api.StorageUploadItem;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/upload/ReactionParticipant.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/upload/ReactionParticipant.java
@@ -1,6 +1,6 @@
 package com.quantori.cqp.api.model.upload;
 
-import com.quantori.cqp.core.model.ReactionParticipantRole;
+import com.quantori.cqp.api.model.ReactionParticipantRole;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/upload/ReactionUploadDocument.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/upload/ReactionUploadDocument.java
@@ -1,7 +1,7 @@
 package com.quantori.cqp.api.model.upload;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.quantori.cqp.core.model.StorageUploadItem;
+import com.quantori.cqp.api.StorageUploadItem;
 
 import java.util.List;
 

--- a/cqp-api/src/test/java/com/quantori/cqp/api/ProcessChiralStructuresTest.java
+++ b/cqp-api/src/test/java/com/quantori/cqp/api/ProcessChiralStructuresTest.java
@@ -5,8 +5,8 @@ import static org.junit.Assert.assertTrue;
 import com.epam.indigo.Indigo;
 import com.quantori.cqp.api.indigo.IndigoMatcher;
 import com.quantori.cqp.api.indigo.IndigoProvider;
-import com.quantori.cqp.core.model.ExactParams;
-import com.quantori.cqp.core.model.SubstructureParams;
+import com.quantori.cqp.api.model.ExactParams;
+import com.quantori.cqp.api.model.SubstructureParams;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 

--- a/cqp-api/src/test/java/com/quantori/cqp/api/ProcessStructureTest.java
+++ b/cqp-api/src/test/java/com/quantori/cqp/api/ProcessStructureTest.java
@@ -2,7 +2,7 @@ package com.quantori.cqp.api;
 
 import com.quantori.cqp.api.indigo.IndigoMatcher;
 import com.quantori.cqp.api.indigo.IndigoProvider;
-import com.quantori.cqp.core.model.SubstructureParams;
+import com.quantori.cqp.api.model.SubstructureParams;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;

--- a/cqp-api/src/test/java/com/quantori/cqp/api/StorageLibraryTest.java
+++ b/cqp-api/src/test/java/com/quantori/cqp/api/StorageLibraryTest.java
@@ -17,7 +17,6 @@ import com.quantori.cqp.api.model.Library;
 import com.quantori.cqp.api.model.LibraryType;
 import com.quantori.cqp.api.model.Property;
 import com.quantori.cqp.api.model.upload.Molecule;
-import com.quantori.cqp.core.model.ItemWriter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;


### PR DESCRIPTION
All necessary types moved from "core" to "api".
The "api" module, once imported to project pulls transitive Akka libraries which should not happen, since "api" just basic types
