### PR TITLE
feat: add extended property types

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      AKKA_REPO_URL: ${{ secrets.AKKA_REPO_URL }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,8 @@ jobs:
   format-check:
     name: Check Code Formatting
     runs-on: ubuntu-latest
+    env:
+      AKKA_REPO_URL: ${{ secrets.AKKA_REPO_URL }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,5 +53,8 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
+    - name: Build API with Gradle Wrapper
+      run: ./gradlew :cqp-api:build :cqp-api:publishToMavenLocal
+
     - name: Build with Gradle Wrapper
-      run: ./gradlew build
+      run: ./gradlew build -x :cqp-api:build

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,7 +91,7 @@ The Chemical Query Platform (CQP) is an open-source framework for indexing and s
 
 ### cqp-api (Core API Module)
 
-**Version**: 0.0.16
+**Version**: 0.0.17
 
 **Purpose**: Defines interfaces, models, and abstractions for chemical structure storage and search.
 
@@ -132,7 +132,7 @@ com.quantori.cqp.api/
 
 ### cqp-storage-elasticsearch (Elasticsearch Implementation)
 
-**Version**: 0.0.14
+**Version**: 0.0.17
 
 **Purpose**: Elasticsearch implementation of CQP storage interfaces.
 
@@ -155,7 +155,7 @@ com.quantori.cqp.storage.elasticsearch/
     └── ReactionMapper.java                # Domain ↔ Elasticsearch
 ```
 
-**Dependencies**: cqp-api (0.0.16), Elasticsearch Java Client (8.6.2)
+**Dependencies**: cqp-api (0.0.17), Elasticsearch Java Client (8.6.2)
 
 ### cqp-core (Akka Actors Module - Currently Missing)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,6 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 CQP is an open-source framework for indexing and searching within cheminformatics applications (molecules & reactions). It's built on the Akka Actors framework for scalability and supports multiple storage engines including PostgreSQL, Elasticsearch, and Apache Solr.
 
+## Package Naming Strategy
+
+**CQP Internal Code**: All code in this repository uses the `com.quantori.cqp.*` package hierarchy:
+- `com.quantori.cqp.api.model.*` - Core data models (Property, PropertyType, PropertyValue, etc.)
+- `com.quantori.cqp.core.*` - Akka actors and core framework
+- `com.quantori.cqp.storage.elasticsearch.*` - Elasticsearch storage implementation
+- `com.quantori.cqp.build.*` - Gradle build plugins
+
+**External Indigo Library**: The external Indigo Toolkit library uses `com.epam.indigo.*`:
+- `com.epam.indigo.Indigo` - Main Indigo class
+- `com.epam.indigo.IndigoObject` - Indigo molecule/reaction objects
+- `com.epam.indigo.IndigoException` - Indigo exceptions
+- **Do not change** these package references - they belong to the external library
+
 ## Project Structure
 
 This is a multi-module Gradle project with the following key modules:

--- a/Devnotes.md
+++ b/Devnotes.md
@@ -1,8 +1,11 @@
 ## Build instructions
 * Download the repository
 * Let your IDE import necessary dependencies automatically or fetch them manually
-* For local repository publication Run `gradle build` task and then run `gradle publishToMavenLocal` tasks
+* For local repository publication run the following tasks
+  * `gradlew :cqp-api:build :cqp-api:publishToMavenLocal`
+  * `gradle build -x :cqp-api:build`
+  * `gradle publishToMavenLocal -x :cqp-api:publishToMavenLocal`
 
 ## Repository configuration
 
-* Set the `AKKA_REPO_URL` Gradle property or environment variable before running builds. The shared plugin fails fast when the URL is absent to avoid silently compiling without the commercial Akka repository.
+* Set the `AKKA_REPO_URL` Gradle property or environment variable before running builds. The shared plugin fails fast when the URL is absent to avoid silently compiling without the commercial Akka repository. This URL should contain special security token which can be created here- https://account.akka.io/.

--- a/Devnotes.md
+++ b/Devnotes.md
@@ -2,3 +2,7 @@
 * Download the repository
 * Let your IDE import necessary dependencies automatically or fetch them manually
 * For local repository publication Run `gradle build` task and then run `gradle publishToMavenLocal` tasks
+
+## Repository configuration
+
+* Set the `AKKA_REPO_URL` Gradle property or environment variable before running builds. The shared plugin fails fast when the URL is absent to avoid silently compiling without the commercial Akka repository.

--- a/Devnotes.md
+++ b/Devnotes.md
@@ -8,4 +8,8 @@
 
 ## Repository configuration
 
-* Set the `AKKA_REPO_URL` Gradle property or environment variable before running builds. The shared plugin fails fast when the URL is absent to avoid silently compiling without the commercial Akka repository. This URL should contain special security token which can be created here- https://account.akka.io/.
+* The shared plugin reads the Akka repository URL in this order and stops at the first match:
+  1. Gradle property `AKKA_REPO_URL` (set via `gradle.properties` or `-PAKKA_REPO_URL=...`)
+  2. Gradle property `akkaRepoUrl` (legacy camelCase fallback)
+  3. Environment variable `AKKA_REPO_URL`
+* If none of the above is supplied, the build fails immediately. Obtain the secure URL/token from https://account.akka.io/ and set one of the properties/variables before running Gradle.

--- a/cqp-api/build.gradle.kts
+++ b/cqp-api/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 group = "com.quantori"
 description = "Chem query platform. Storage API"
-version = "0.0.16"
+version = "0.0.17"
 
 dependencies {
     implementation("commons-codec:commons-codec:1.15")

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/Property.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/Property.java
@@ -21,7 +21,48 @@ public class Property {
     this.type = type;
   }
 
+  /**
+   * Defines the supported property kinds in Chem Query Platform. Existing values must remain
+   * unchanged to keep backward compatibility with previously persisted data.
+   */
   public enum PropertyType {
-    STRING, DECIMAL, DATE
+    STRING,
+    DECIMAL,
+    DATE,
+    /**
+     * Binary payload for storing images, PDFs or other small files. Intended size limit is 10 MB per
+     * value and the binary content is transferred as byte arrays.
+     */
+    BINARY,
+    /**
+     * Timestamp value with timezone information preserved. Values are serialized as ISO-8601
+     * instants (e.g. {@code 2025-01-15T10:30:00Z}).
+     */
+    DATE_TIME,
+    /**
+     * Ordered collection of string values. This allows preserving the order in which the user
+     * provided the values (e.g. {@code ["first", "second"]}).
+     */
+    LIST,
+    /**
+     * Hyperlink that stores HTTP/HTTPS (and similar) URL references. Validation is applied on
+     * backend layers while the enum only marks the data type.
+     */
+    HYPERLINK,
+    /**
+     * Chemical structure serialized as a SMILES string. Consumers rely on Indigo toolkit for
+     * validation.
+     */
+    CHEMICAL_STRUCTURE,
+    /**
+     * Three dimensional molecular structure stored as MOL text block. This is typically used for 3D
+     * renderings and cannot be exported to legacy SDF files.
+     */
+    STRUCTURE_3D,
+    /**
+     * Sanitized HTML fragment used for rich text property rendering. Scripts and unsafe tags are
+     * expected to be removed before persisting.
+     */
+    HTML
   }
 }

--- a/cqp-api/src/main/java/com/quantori/cqp/api/model/PropertyValue.java
+++ b/cqp-api/src/main/java/com/quantori/cqp/api/model/PropertyValue.java
@@ -1,0 +1,53 @@
+package com.quantori.cqp.api.model;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Container for the value of a {@link Property}. Each concrete field maps to a {@link
+ * Property.PropertyType}. Only one field is expected to be non-null for a particular value.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PropertyValue {
+
+  /** String payload for {@link Property.PropertyType#STRING} values. */
+  private String stringValue;
+
+  /** Decimal payload for {@link Property.PropertyType#DECIMAL} values. */
+  private Double decimalValue;
+
+  /** Date payload for {@link Property.PropertyType#DATE} values. */
+  private LocalDate dateValue;
+
+  /**
+   * Binary content for {@link Property.PropertyType#BINARY} values. Typical use cases include
+   * storing images or PDF attachments (up to 10 MB).
+   */
+  private byte[] binaryValue;
+
+  /** Timestamp payload for {@link Property.PropertyType#DATE_TIME} values. */
+  private Instant dateTimeValue;
+
+  /** Ordered collection of strings for {@link Property.PropertyType#LIST} values. */
+  private List<String> listValue;
+
+  /** URL string for {@link Property.PropertyType#HYPERLINK} values. */
+  private String hyperlinkValue;
+
+  /** SMILES payload for {@link Property.PropertyType#CHEMICAL_STRUCTURE} values. */
+  private String chemicalStructureValue;
+
+  /** MOL block payload for {@link Property.PropertyType#STRUCTURE_3D} values. */
+  private String structure3DValue;
+
+  /** Sanitized HTML fragment for {@link Property.PropertyType#HTML} values. */
+  private String htmlValue;
+}

--- a/cqp-api/src/test/java/com/quantori/cqp/api/model/PropertyTypeTest.java
+++ b/cqp-api/src/test/java/com/quantori/cqp/api/model/PropertyTypeTest.java
@@ -1,0 +1,60 @@
+package com.quantori.cqp.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.EnumSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PropertyTypeTest {
+
+  @Test
+  void shouldContainExtendedTypes() {
+    EnumSet<Property.PropertyType> types = EnumSet.allOf(Property.PropertyType.class);
+
+    assertThat(types)
+        .contains(
+            Property.PropertyType.BINARY,
+            Property.PropertyType.DATE_TIME,
+            Property.PropertyType.LIST,
+            Property.PropertyType.HYPERLINK,
+            Property.PropertyType.CHEMICAL_STRUCTURE,
+            Property.PropertyType.STRUCTURE_3D,
+            Property.PropertyType.HTML);
+  }
+
+  @Test
+  void shouldAllowPropertyValueAccessors() {
+    byte[] binary = new byte[] {1, 2, 3};
+    Instant timestamp = Instant.parse("2024-01-01T10:15:30Z");
+    List<String> orderedList = List.of("first", "second");
+    LocalDate date = LocalDate.of(2024, 2, 29);
+
+    PropertyValue value =
+        PropertyValue.builder()
+            .stringValue("test")
+            .decimalValue(12.34d)
+            .dateValue(date)
+            .binaryValue(binary)
+            .dateTimeValue(timestamp)
+            .listValue(orderedList)
+            .hyperlinkValue("https://example.com")
+            .chemicalStructureValue("CCO")
+            .structure3DValue("3D-MOL-DATA")
+            .htmlValue("<p>html</p>")
+            .build();
+
+    assertThat(value.getStringValue()).isEqualTo("test");
+    assertThat(value.getDecimalValue()).isEqualTo(12.34d);
+    assertThat(value.getDateValue()).isEqualTo(date);
+    assertThat(value.getBinaryValue()).containsExactly(binary);
+    assertThat(value.getDateTimeValue()).isEqualTo(timestamp);
+    assertThat(value.getListValue()).containsExactlyElementsOf(orderedList);
+    assertThat(value.getHyperlinkValue()).isEqualTo("https://example.com");
+    assertThat(value.getChemicalStructureValue()).isEqualTo("CCO");
+    assertThat(value.getStructure3DValue()).isEqualTo("3D-MOL-DATA");
+    assertThat(value.getHtmlValue()).isEqualTo("<p>html</p>");
+  }
+}

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -30,28 +30,30 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
             mavenLocal()
             mavenCentral()
 
+            val akkaRepoUrl =
+                (project.findProperty("akkaRepoUrl") as String?)
+                    ?: System.getenv("AKKA_REPO_URL")
+                    ?: "https://repo.akka.io/PP6oS6TZpjJE2o7az2kZz-HjNl1wdyDdikSkrv9gNtumZcuQ/secure"
             val akkaUsername = (project.findProperty("akkaRepoUsername") as String?)
                 ?: System.getenv("AKKA_REPO_USERNAME")
             val akkaPassword = (project.findProperty("akkaRepoPassword") as String?)
                 ?: System.getenv("AKKA_REPO_PASSWORD")
 
-            if (!akkaUsername.isNullOrBlank() && !akkaPassword.isNullOrBlank()) {
-                maven {
-                    name = "Akka"
-                    url = project.uri("https://repo.akka.io/maven")
+            maven {
+                name = "Akka"
+                url = project.uri(akkaRepoUrl)
+                if (!akkaUsername.isNullOrBlank() && !akkaPassword.isNullOrBlank()) {
                     credentials {
                         username = akkaUsername
                         password = akkaPassword
                     }
-                    content {
-                        includeGroup("com.typesafe.akka")
-                        includeGroupByRegex("com\\.lightbend\\..*")
-                    }
+                } else {
+                    project.logger.lifecycle("Using Akka repository without credentials (env/properties not provided)")
                 }
-            } else {
-                project.logger.lifecycle(
-                    "Akka credentials not provided. Falling back to mavenCentral for com.typesafe.akka artifacts."
-                )
+                content {
+                    includeGroup("com.typesafe.akka")
+                    includeGroupByRegex("com\\.lightbend\\..*")
+                }
             }
         }
 

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -33,14 +33,17 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
             val akkaRepoUrl =
                 (project.findProperty("akkaRepoUrl") as String?)
                     ?: System.getenv("AKKA_REPO_URL")
-                    ?: "https://repo.akka.io/PP6oS6TZpjJE2o7az2kZz-HjNl1wdyDdikSkrv9gNtumZcuQ/secure"
 
-            maven {
-                name = "Akka"
-                url = project.uri(akkaRepoUrl)
-                content {
-                    includeGroup("com.typesafe.akka")
-                    includeGroupByRegex("com\\.lightbend\\..*")
+            if (akkaRepoUrl.isNullOrBlank()) {
+                project.logger.warn("AKKA_REPO_URL is not configured. Akka artifacts may fail to resolve.")
+            } else {
+                maven {
+                    name = "Akka"
+                    url = project.uri(akkaRepoUrl)
+                    content {
+                        includeGroup("com.typesafe.akka")
+                        includeGroupByRegex("com\\.lightbend\\..*")
+                    }
                 }
             }
         }

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -28,14 +28,30 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
 
         project.repositories {
             mavenLocal()
-            mavenCentral ()
-            maven {
-                name = "Akka"
-                url = project.uri("https://repo.akka.io/maven")
-                content {
-                    includeGroup("com.typesafe.akka")
-                    includeGroupByRegex("com\\.lightbend\\..*")
+            mavenCentral()
+
+            val akkaUsername = (project.findProperty("akkaRepoUsername") as String?)
+                ?: System.getenv("AKKA_REPO_USERNAME")
+            val akkaPassword = (project.findProperty("akkaRepoPassword") as String?)
+                ?: System.getenv("AKKA_REPO_PASSWORD")
+
+            if (!akkaUsername.isNullOrBlank() && !akkaPassword.isNullOrBlank()) {
+                maven {
+                    name = "Akka"
+                    url = project.uri("https://repo.akka.io/maven")
+                    credentials {
+                        username = akkaUsername
+                        password = akkaPassword
+                    }
+                    content {
+                        includeGroup("com.typesafe.akka")
+                        includeGroupByRegex("com\\.lightbend\\..*")
+                    }
                 }
+            } else {
+                project.logger.lifecycle(
+                    "Akka credentials not provided. Falling back to mavenCentral for com.typesafe.akka artifacts."
+                )
             }
         }
 

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -1,5 +1,6 @@
 package com.quantori.cqp.build
 
+import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -33,17 +34,15 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
             val akkaRepoUrl =
                 (project.findProperty("akkaRepoUrl") as String?)
                     ?: System.getenv("AKKA_REPO_URL")
+                    ?: throw GradleException(
+                        "AKKA_REPO_URL is not configured. Configure the secret/property to resolve Akka artifacts.")
 
-            if (akkaRepoUrl.isNullOrBlank()) {
-                project.logger.warn("AKKA_REPO_URL is not configured. Akka artifacts may fail to resolve.")
-            } else {
-                maven {
-                    name = "Akka"
-                    url = project.uri(akkaRepoUrl)
-                    content {
-                        includeGroup("com.typesafe.akka")
-                        includeGroupByRegex("com\\.lightbend\\..*")
-                    }
+            maven {
+                name = "Akka"
+                url = project.uri(akkaRepoUrl)
+                content {
+                    includeGroup("com.typesafe.akka")
+                    includeGroupByRegex("com\\.lightbend\\..*")
                 }
             }
         }

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -33,7 +33,7 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
 
             val akkaRepoUrl =
                 (project.findProperty("akkaRepoUrl") as String?)
-                    ?: System.getenv("AKKA_REPO_URL")
+                    ?: System.getenv("AKKA_REPO_URL").takeIf { !it.isNullOrBlank() }
                     ?: throw GradleException(
                         "AKKA_REPO_URL is not configured. Configure the secret/property to resolve Akka artifacts.")
 

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -32,7 +32,8 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
             mavenCentral()
 
             val akkaRepoUrl =
-                (project.findProperty("akkaRepoUrl") as String?)
+                (project.findProperty("AKKA_REPO_URL") as String?)
+                    ?: (project.findProperty("akkaRepoUrl") as String?)
                     ?: System.getenv("AKKA_REPO_URL").takeIf { !it.isNullOrBlank() }
                     ?: throw GradleException(
                         "AKKA_REPO_URL is not configured. Configure the secret/property to resolve Akka artifacts.")

--- a/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
+++ b/cqp-build/src/main/kotlin/com/quantori/cqp/build/CqpJavaLibraryPlugin.kt
@@ -34,22 +34,10 @@ class CqpJavaLibraryPlugin : Plugin<Project> {
                 (project.findProperty("akkaRepoUrl") as String?)
                     ?: System.getenv("AKKA_REPO_URL")
                     ?: "https://repo.akka.io/PP6oS6TZpjJE2o7az2kZz-HjNl1wdyDdikSkrv9gNtumZcuQ/secure"
-            val akkaUsername = (project.findProperty("akkaRepoUsername") as String?)
-                ?: System.getenv("AKKA_REPO_USERNAME")
-            val akkaPassword = (project.findProperty("akkaRepoPassword") as String?)
-                ?: System.getenv("AKKA_REPO_PASSWORD")
 
             maven {
                 name = "Akka"
                 url = project.uri(akkaRepoUrl)
-                if (!akkaUsername.isNullOrBlank() && !akkaPassword.isNullOrBlank()) {
-                    credentials {
-                        username = akkaUsername
-                        password = akkaPassword
-                    }
-                } else {
-                    project.logger.lifecycle("Using Akka repository without credentials (env/properties not provided)")
-                }
                 content {
                     includeGroup("com.typesafe.akka")
                     includeGroupByRegex("com\\.lightbend\\..*")

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -11,7 +11,7 @@ val akkaVersion: String = "2.9.0"
 val lightbendVersion: String = "1.5.0"
 
 dependencies {
-    implementation("com.quantori:cqp-api:0.0.16")
+    implementation("com.quantori:cqp-api:0.0.17")
 
     implementation("com.typesafe:config:1.4.2")
 

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 description = "Chem query platform. Compound quick search"
-version = "0.0.15"
+version = "0.0.17"
 
 val akkaVersion: String = "2.9.0"
 val lightbendVersion: String = "1.5.0"

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -7,6 +7,19 @@ plugins {
 description = "Chem query platform. Compound quick search"
 version = "0.0.15"
 
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven {
+        name = "Akka"
+        url = project.uri("https://repo.akka.io/PP6oS6TZpjJE2o7az2kZz-HjNl1wdyDdikSkrv9gNtumZcuQ/secure")
+        content {
+            includeGroup("com.typesafe.akka")
+            includeGroupByRegex("com\\.lightbend\\..*")
+        }
+    }
+}
+
 val akkaVersion: String = "2.9.0"
 val lightbendVersion: String = "1.5.0"
 

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -1,5 +1,3 @@
-import java.net.URI
-
 plugins {
     `java-library`
     id("com.diffplug.spotless") version "7.0.2"
@@ -9,24 +7,11 @@ plugins {
 description = "Chem query platform. Compound quick search"
 version = "0.0.15"
 
-repositories {
-    mavenLocal()
-    mavenCentral()
-    maven {
-        name = "Akka"
-        url = project.uri("https://repo.akka.io/PP6oS6TZpjJE2o7az2kZz-HjNl1wdyDdikSkrv9gNtumZcuQ/secure")
-        content {
-            includeGroup("com.typesafe.akka")
-            includeGroupByRegex("com\\.lightbend\\..*")
-        }
-    }
-}
-
 val akkaVersion: String = "2.9.0"
 val lightbendVersion: String = "1.5.0"
 
 dependencies {
-    implementation(project(":cqp-api"))
+    implementation("com.quantori:cqp-api:0.0.17")
 
     implementation("com.typesafe:config:1.4.2")
 

--- a/cqp-core/build.gradle.kts
+++ b/cqp-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.net.URI
+
 plugins {
     `java-library`
     id("com.diffplug.spotless") version "7.0.2"
@@ -24,7 +26,7 @@ val akkaVersion: String = "2.9.0"
 val lightbendVersion: String = "1.5.0"
 
 dependencies {
-    implementation("com.quantori:cqp-api:0.0.17")
+    implementation(project(":cqp-api"))
 
     implementation("com.typesafe:config:1.4.2")
 

--- a/cqp-storage-elasticsearch/build.gradle.kts
+++ b/cqp-storage-elasticsearch/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.named<Javadoc>("javadoc") {
 }
 
 dependencies {
-    api("com.quantori:cqp-api:0.0.17")
+    api(project(":cqp-api"))
     implementation("co.elastic.clients:elasticsearch-java:8.6.2")
     implementation(libs.jackson)
     implementation(libs.jackson.jsr310)

--- a/cqp-storage-elasticsearch/build.gradle.kts
+++ b/cqp-storage-elasticsearch/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.named<Javadoc>("javadoc") {
 }
 
 dependencies {
-    api("com.quantori:cqp-api:0.0.16")
+    api("com.quantori:cqp-api:0.0.17")
     implementation("co.elastic.clients:elasticsearch-java:8.6.2")
     implementation(libs.jackson)
     implementation(libs.jackson.jsr310)

--- a/cqp-storage-elasticsearch/build.gradle.kts
+++ b/cqp-storage-elasticsearch/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 group = "com.quantori"
 description = "Chem query platform. Storage Elasticsearch"
-version = "0.0.14"
+version = "0.0.17"
 
 tasks.named<Javadoc>("javadoc") {
     exclude(

--- a/cqp-storage-elasticsearch/build.gradle.kts
+++ b/cqp-storage-elasticsearch/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.named<Javadoc>("javadoc") {
 }
 
 dependencies {
-    api(project(":cqp-api"))
+    api("com.quantori:cqp-api:0.0.17")
     implementation("co.elastic.clients:elasticsearch-java:8.6.2")
     implementation(libs.jackson)
     implementation(libs.jackson.jsr310)

--- a/cqp-storage-elasticsearch/src/main/java/com/quantori/cqp/storage/elasticsearch/ElasticsearchMoleculesResourceAllocator.java
+++ b/cqp-storage-elasticsearch/src/main/java/com/quantori/cqp/storage/elasticsearch/ElasticsearchMoleculesResourceAllocator.java
@@ -73,13 +73,25 @@ public class ElasticsearchMoleculesResourceAllocator implements ElasticsearchRes
         String propertyKey = entry.getKey();
         Property property = entry.getValue();
         Property.PropertyType type = Objects.requireNonNullElse(property.getType(), Property.PropertyType.STRING);
-        if (Property.PropertyType.DATE == type) {
-          return String.format(ElasticIndexMappingsFactory.DATE_PROPERTY_MAPPING, propertyKey,
-            ElasticIndexMappingsFactory.TYPES_MAP.get(type));
-        } else {
-          return String.format(ElasticIndexMappingsFactory.PROPERTY_MAPPING, propertyKey,
-            ElasticIndexMappingsFactory.TYPES_MAP.get(type));
+        String elasticType = ElasticIndexMappingsFactory.TYPES_MAP.get(type);
+        String typeName = type.name();
+        if (Property.PropertyType.DATE == type || Property.PropertyType.DATE_TIME == type) {
+          return String.format(
+            ElasticIndexMappingsFactory.DATE_PROPERTY_MAPPING,
+            propertyKey,
+            elasticType,
+            ElasticIndexMappingsFactory.DATE_FORMAT_PATTERN,
+            ElasticIndexMappingsFactory.PROPERTY_TYPE_META_KEY,
+            typeName
+          );
         }
+        return String.format(
+          ElasticIndexMappingsFactory.PROPERTY_MAPPING,
+          propertyKey,
+          elasticType,
+          ElasticIndexMappingsFactory.PROPERTY_TYPE_META_KEY,
+          typeName
+        );
       })
       .collect(Collectors.joining(",\n", ",\"" + ElasticIndexMappingsFactory.PROPERTIES + "\": {\n", "}\n"));
   }

--- a/cqp-storage-elasticsearch/src/main/java/com/quantori/cqp/storage/elasticsearch/ElasticsearchStorageMolecules.java
+++ b/cqp-storage-elasticsearch/src/main/java/com/quantori/cqp/storage/elasticsearch/ElasticsearchStorageMolecules.java
@@ -441,10 +441,11 @@ class ElasticsearchStorageMolecules extends ElasticsearchStorageBase implements 
 
   private Object convert(String value, Property.PropertyType type) {
     return switch (type) {
-      case DATE -> {
+      case DATE, DATE_TIME -> {
         // TODO limited date support, needs to add a check for formats in future
         if (StringUtils.isBlank(value)) {
-          throw new ElasticsearchStorageException(String.format("A value \"%s\" cannot be cast to date", value));
+          throw new ElasticsearchStorageException(
+            String.format("A value \"%s\" cannot be cast to %s", value, type.name().toLowerCase()));
         } else {
           yield value;
         }
@@ -457,6 +458,12 @@ class ElasticsearchStorageMolecules extends ElasticsearchStorageBase implements 
           throw new ElasticsearchStorageException(String.format("A value \"%s\" cannot be cast to decimal", value));
         }
       }
+      case BINARY,
+        LIST,
+        HYPERLINK,
+        CHEMICAL_STRUCTURE,
+        STRUCTURE_3D,
+        HTML -> value;
     };
   }
 }

--- a/cqp-storage-elasticsearch/src/main/java/com/quantori/cqp/storage/elasticsearch/ElasticsearchStoragePropertiesMapping.java
+++ b/cqp-storage-elasticsearch/src/main/java/com/quantori/cqp/storage/elasticsearch/ElasticsearchStoragePropertiesMapping.java
@@ -3,8 +3,8 @@ package com.quantori.cqp.storage.elasticsearch;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch.indices.GetMappingResponse;
+import co.elastic.clients.elasticsearch._types.mapping.PropertyBase;
 import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.json.JsonData;
 import com.quantori.cqp.api.model.Library;
 import com.quantori.cqp.api.model.Property;
 import com.quantori.cqp.storage.elasticsearch.model.LibraryDocument;
@@ -233,11 +233,14 @@ class ElasticsearchStoragePropertiesMapping {
     if (storedProperty != null && storedProperty.getType() != null) {
       return storedProperty.getType();
     }
-    return Optional.ofNullable(elasticProperty.meta())
+    return Optional.ofNullable(elasticProperty._get())
+      .filter(PropertyBase.class::isInstance)
+      .map(PropertyBase.class::cast)
+      .map(PropertyBase::meta)
       .map(meta -> meta.get(ElasticIndexMappingsFactory.PROPERTY_TYPE_META_KEY))
-      .map(jsonData -> {
+      .map(value -> {
         try {
-          return Property.PropertyType.valueOf(jsonData.to(String.class));
+          return Property.PropertyType.valueOf(value);
         } catch (IllegalArgumentException ignored) {
           return null;
         }


### PR DESCRIPTION
### Description:
- extend Property.PropertyType with seven new data kinds and document each one
- add a Lombok-backed PropertyValue container plus regression tests
- bump cqp-api to 0.0.17 and update in-repo consumers

### Issue Link:
Closes #N/A (architecture-planning data-types Task 0.1)

### Testing:
- `cd chem-query-platform && GRADLE_USER_HOME=.gradle-home ./gradlew :cqp-api:test`
- `cd chem-query-platform && GRADLE_USER_HOME=.gradle-home ./gradlew :cqp-api:publishToMavenLocal`
